### PR TITLE
improve phpdoc

### DIFF
--- a/Request.php
+++ b/Request.php
@@ -184,7 +184,7 @@ class Request
     protected $format;
 
     /**
-     * @var SessionInterface
+     * @var SessionInterface|callable
      */
     protected $session;
 


### PR DESCRIPTION
hi
Function name must be callable - a string, Closure or class implementing __invoke, currently \Symfony\Component\HttpFoundation\Session\SessionInterface or callable on phpdoc
![image](https://user-images.githubusercontent.com/11363999/97445629-b929ea80-1942-11eb-87ad-f66c0f790b86.png)
